### PR TITLE
Gemfile update 2018 12 26

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.2)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.2)
       rack
     rack-test (1.0.0)

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,6 @@
-require './config/environment'
+require "./config/environment"
 
-if ActiveRecord::Migrator.needs_migration?
+if ActiveRecord::Base.connection.migration_context.needs_migration?
   raise 'Migrations are pending. Run `rake db:migrate` to resolve the issue.'
 end
 


### PR DESCRIPTION
Updated rack version.

Changed: `ActiveRecord::Migrator.needs_migration?` to `ActiveRecord::Base.connection.migration_context.needs_migration?`

https://stackoverflow.com/questions/50790649/nomethoderror-undefined-method-needs-migration-for-activerecordmigratorcl